### PR TITLE
Made sure DateTime casts are converted to strings

### DIFF
--- a/src/Laravel/EventListener.php
+++ b/src/Laravel/EventListener.php
@@ -85,6 +85,13 @@ class EventListener
                       "/" .
                       $pdo->getAttribute(\PDO::ATTR_SERVER_VERSION);
             
+            // Laravel casting returns some items as DateTime objects
+            foreach ($event->bindings as $key => $binding) {
+                if (is_a($binding, 'DateTime')) {
+                    $event->bindings[$key] = $binding->format('Y-m-d H:i:s');
+                }
+            }
+            
             // Replace bindings with real values
             $sql = str_replace(['%', '?'], ['%%', '%s'], $event->sql);
             $sql = vsprintf($sql, $event->bindings);


### PR DESCRIPTION
When using casts in laravel, you sometimes get DateTime objects - which causes an exception to be thrown.

e.g. When you have

```
protected $dates = [
        'active_at', 'created_at', 'updated_at'
];
```

It will cause an error similar to 

```
{
    "data": [
        {
            "field": "Symfony\\Component\\Debug\\Exception\\FatalErrorException",
            "messages": [
                [
                    "Object of class DateTime could not be converted to string",
                    "/Users/owen/Sites/alshirawi/vendor/lezhnev74/apideveloperio-laravel/src/Laravel/EventListener.php",
                    90
                ]
            ]
        }
    ],
    "meta": {
        "success": false,
        "error_code": 400
    }
}
```

It can be solved by converting the bindings to a string first.

This PR just loops through each binding converting it before passing to the PDO.