### PR TITLE
Support Laravel 5.6

### DIFF
--- a/src/Laravel/DumpRecordedRequests.php
+++ b/src/Laravel/DumpRecordedRequests.php
@@ -7,7 +7,7 @@ namespace HttpAnalyzer\Laravel;
 
 use Illuminate\Config\Repository;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface;
 
 final class DumpRecordedRequests extends Command
 {
@@ -15,13 +15,13 @@ final class DumpRecordedRequests extends Command
     protected $description = 'Send recorded http requests to API backend and them remove them from local filesystem';
     /** @var  Repository */
     private $config_repo;
-    /** @var  Log */
+    /** @var  LoggerInterface */
     private $log;
     /** @var  GuzzleHttpClient */
     private $guzzle_http_client;
     
     
-    public function __construct(Repository $config_repo, Log $log, GuzzleHttpClient $client)
+    public function __construct(Repository $config_repo, LoggerInterface $log, GuzzleHttpClient $client)
     {
         $this->config_repo        = $config_repo;
         $this->log                = $log;

--- a/src/Laravel/EventListener.php
+++ b/src/Laravel/EventListener.php
@@ -8,7 +8,7 @@ namespace HttpAnalyzer\Laravel;
 
 use HttpAnalyzer\Backend\LoggedRequest;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,7 +28,7 @@ class EventListener
     ];
     /** @var  Repository */
     private $config_repo;
-    /** @var  Log */
+    /** @var  LoggerInterface */
     private $log_writer;
     
     /**
@@ -36,7 +36,7 @@ class EventListener
      *
      * @param Repository $config_repo
      */
-    public function __construct(Repository $config_repo, Log $log)
+    public function __construct(Repository $config_repo, LoggerInterface $log)
     {
         $this->config_repo = $config_repo;
         $this->log_writer  = $log;

--- a/src/Laravel/HttpAnalyzerServiceProvider.php
+++ b/src/Laravel/HttpAnalyzerServiceProvider.php
@@ -4,7 +4,7 @@ namespace HttpAnalyzer\Laravel;
 
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Log\Events\MessageLogged;
@@ -63,7 +63,7 @@ final class HttpAnalyzerServiceProvider extends ServiceProvider
         $this->app->singleton(EventListener::class, function ($app) {
             return new EventListener(
                 $app[Repository::class],
-                $app[Log::class]
+                $app[LoggerInterface::class]
             );
         });
         


### PR DESCRIPTION
### [The `Illuminate\Contracts\Logging\Log` Interface](https://laravel.com/docs/5.6/upgrade)
This interface has been removed since this interface was a total duplication of the  `Psr\Log\LoggerInterface` interface. You should type-hint the `Psr\Log\LoggerInterface` interface instead.