### PR TITLE
Add DiversiTest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=5.6",
         "guzzlehttp/guzzle": "~5.0|~6.0",
         "illuminate/support": "~5.2",
-        "ob-ivan/diversitest": "^0.4.1",
+        "ob-ivan/diversitest": "^0.5",
         "ramsey/uuid": "~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     },
     "require": {
         "php": ">=5.6",
-        "illuminate/support": "~5.2",
         "guzzlehttp/guzzle": "~5.0|~6.0",
+        "illuminate/support": "~5.2",
+        "ob-ivan/diversitest": "^0.4.1",
         "ramsey/uuid": "~3.0"
     },
     "require-dev": {
-        "ob-ivan/diversitest": "^0.3",
         "orchestra/testbench": "^3.2|^3.3|^3.4|^3.5|^3.6",
         "phpunit/phpunit": "~5.0|~6.0|~7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0|~6.0|~7.0",
-        "orchestra/testbench": "^3.2|^3.3|^3.4|^3.5|^3.6"
+        "orchestra/testbench": "^3.2|^3.3|^3.4|^3.5|^3.6",
+        "ob-ivan/diversitest": "^0.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
             "email": "lezhnev.work@gmail.com"
         }
     ],
+    "config": {
+        "sort_packages": true
+    },
     "require": {
         "php": ">=5.6",
         "illuminate/support": "~5.2",
@@ -26,7 +29,7 @@
     "require-dev": {
         "phpunit/phpunit": "~5.0|~6.0|~7.0",
         "orchestra/testbench": "^3.2|^3.3|^3.4|^3.5|^3.6",
-        "ob-ivan/diversitest": "^0.1.0"
+        "ob-ivan/diversitest": "^0.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "config": {
-        "sort_packages": true
+        "sort-packages": true
     },
     "require": {
         "php": ">=5.6",
@@ -27,9 +27,9 @@
         "ramsey/uuid": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0|~6.0|~7.0",
+        "ob-ivan/diversitest": "^0.3",
         "orchestra/testbench": "^3.2|^3.3|^3.4|^3.5|^3.6",
-        "ob-ivan/diversitest": "^0.2"
+        "phpunit/phpunit": "~5.0|~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "php": ">=5.6",
         "guzzlehttp/guzzle": "~5.0|~6.0",
         "illuminate/support": "~5.2",
-        "ob-ivan/diversitest": "^0.5",
         "ramsey/uuid": "~3.0"
     },
     "require-dev": {
+        "ob-ivan/diversitest": "^0.5",
         "orchestra/testbench": "^3.2|^3.3|^3.4|^3.5|^3.6",
         "phpunit/phpunit": "~5.0|~6.0|~7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ramsey/uuid": "~3.0"
     },
     "require-dev": {
-        "ob-ivan/diversitest": "^0.5",
+        "ob-ivan/diversitest": "^0.5.1",
         "orchestra/testbench": "^3.2|^3.3|^3.4|^3.5|^3.6",
         "phpunit/phpunit": "~5.0|~6.0|~7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "~5.0|~6.0",
         "illuminate/support": "~5.2",
+        "guzzlehttp/guzzle": "~5.0|~6.0",
         "ramsey/uuid": "~3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "73f8ec398c6c55210f9e50a773e9b93b",
+    "content-hash": "b8ab736acfaf8a536e527e1a79ed4f26",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -2242,20 +2242,21 @@
         },
         {
             "name": "ob-ivan/diversitest",
-            "version": "v0.2",
+            "version": "v0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ob-ivan/diversitest.git",
-                "reference": "ce7ae585714c9cd0c349d93d90f3ae68cfa3157f"
+                "reference": "5a9ad45248c252b05a6b21382df7d78733d7b901"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/ce7ae585714c9cd0c349d93d90f3ae68cfa3157f",
-                "reference": "ce7ae585714c9cd0c349d93d90f3ae68cfa3157f",
+                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/5a9ad45248c252b05a6b21382df7d78733d7b901",
+                "reference": "5a9ad45248c252b05a6b21382df7d78733d7b901",
                 "shasum": ""
             },
             "require": {
                 "symfony/console": "^4.0",
+                "symfony/process": "^4.0",
                 "symfony/yaml": "^4.0"
             },
             "require-dev": {
@@ -2272,7 +2273,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Run tests against varying dependencies versions",
-            "time": "2018-02-19T22:17:10+00:00"
+            "time": "2018-02-19T23:31:17+00:00"
         },
         {
             "name": "orchestra/testbench",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8ab736acfaf8a536e527e1a79ed4f26",
+    "content-hash": "38f9111aa212aede13b1b3377d5789be",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -808,6 +808,41 @@
                 "time"
             ],
             "time": "2017-01-16T07:55:07+00:00"
+        },
+        {
+            "name": "ob-ivan/diversitest",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ob-ivan/diversitest.git",
+                "reference": "b39417da9bd6b802b86d64765b54acb8d42b842d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/b39417da9bd6b802b86d64765b54acb8d42b842d",
+                "reference": "b39417da9bd6b802b86d64765b54acb8d42b842d",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/console": "^3.0|^4.0",
+                "symfony/process": "^3.0|^4.0",
+                "symfony/yaml": "^3.0|^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "bin": [
+                "diversitest"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ob_Ivan\\DiversiTest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "Run tests against varying dependencies versions",
+            "time": "2018-02-23T21:27:44+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1993,6 +2028,64 @@
             "time": "2018-01-29T09:06:29+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
+                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-21T19:06:11+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "2.2.1",
             "source": {
@@ -2239,41 +2332,6 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
-        },
-        {
-            "name": "ob-ivan/diversitest",
-            "version": "v0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ob-ivan/diversitest.git",
-                "reference": "5a9ad45248c252b05a6b21382df7d78733d7b901"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/5a9ad45248c252b05a6b21382df7d78733d7b901",
-                "reference": "5a9ad45248c252b05a6b21382df7d78733d7b901",
-                "shasum": ""
-            },
-            "require": {
-                "symfony/console": "^4.0",
-                "symfony/process": "^4.0",
-                "symfony/yaml": "^4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "bin": [
-                "diversitest"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Ob_Ivan\\DiversiTest\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "description": "Run tests against varying dependencies versions",
-            "time": "2018-02-19T23:31:17+00:00"
         },
         {
             "name": "orchestra/testbench",
@@ -3655,64 +3713,6 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
-                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-01-21T19:06:11+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a95fb8fcb90f283c1044bf026e3271c1",
+    "content-hash": "f299ba419a30d76e66c8a3f4ec646756",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -461,16 +461,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.6.3",
+            "version": "v5.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "db3e5422070d9b5166493313142b30419efab207"
+                "reference": "2e68209991e15aca1382ef9a3443d13f2e0d8755"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/db3e5422070d9b5166493313142b30419efab207",
-                "reference": "db3e5422070d9b5166493313142b30419efab207",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/2e68209991e15aca1382ef9a3443d13f2e0d8755",
+                "reference": "2e68209991e15aca1382ef9a3443d13f2e0d8755",
                 "shasum": ""
             },
             "require": {
@@ -481,7 +481,7 @@
                 "ext-openssl": "*",
                 "league/flysystem": "~1.0",
                 "monolog/monolog": "~1.12",
-                "nesbot/carbon": "~1.20",
+                "nesbot/carbon": "^1.22.1",
                 "php": "^7.1.3",
                 "psr/container": "~1.0",
                 "psr/simple-cache": "^1.0",
@@ -527,7 +527,7 @@
                 "illuminate/translation": "self.version",
                 "illuminate/validation": "self.version",
                 "illuminate/view": "self.version",
-                "tightenco/collect": "self.version"
+                "tightenco/collect": "<5.5.33"
             },
             "require-dev": {
                 "aws/aws-sdk-php": "~3.0",
@@ -592,7 +592,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2018-02-09T13:33:22+00:00"
+            "time": "2018-02-22T19:21:38+00:00"
         },
         {
             "name": "league/flysystem",
@@ -808,42 +808,6 @@
                 "time"
             ],
             "time": "2017-01-16T07:55:07+00:00"
-        },
-        {
-            "name": "ob-ivan/diversitest",
-            "version": "v0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ob-ivan/diversitest.git",
-                "reference": "baf09afe79ebe3f51ca569883752b668b457301e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/baf09afe79ebe3f51ca569883752b668b457301e",
-                "reference": "baf09afe79ebe3f51ca569883752b668b457301e",
-                "shasum": ""
-            },
-            "require": {
-                "symfony/console": "^3.0|^4.0",
-                "symfony/process": "^3.0|^4.0",
-                "symfony/yaml": "^3.0|^4.0",
-                "twig/twig": "^2.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "bin": [
-                "diversitest"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Ob_Ivan\\DiversiTest\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "description": "Run tests against varying dependencies versions",
-            "time": "2018-02-23T23:44:52+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -2029,64 +1993,6 @@
             "time": "2018-01-29T09:06:29+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
-                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-01-21T19:06:11+00:00"
-        },
-        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "2.2.1",
             "source": {
@@ -2132,72 +2038,6 @@
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "time": "2017-11-27T11:13:29+00:00"
-        },
-        {
-            "name": "twig/twig",
-            "version": "v2.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/twigphp/Twig.git",
-                "reference": "eddb97148ad779f27e670e1e3f19fb323aedafeb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/eddb97148ad779f27e670e1e3f19fb323aedafeb",
-                "reference": "eddb97148ad779f27e670e1e3f19fb323aedafeb",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "symfony/polyfill-mbstring": "~1.0"
-            },
-            "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~3.3@dev"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
-                },
-                "psr-4": {
-                    "Twig\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Armin Ronacher",
-                    "email": "armin.ronacher@active-4.com",
-                    "role": "Project Founder"
-                },
-                {
-                    "name": "Twig Team",
-                    "homepage": "http://twig.sensiolabs.org/contributors",
-                    "role": "Contributors"
-                }
-            ],
-            "description": "Twig, the flexible, fast, and secure template language for PHP",
-            "homepage": "http://twig.sensiolabs.org",
-            "keywords": [
-                "templating"
-            ],
-            "time": "2017-09-27T18:10:31+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -2401,22 +2241,58 @@
             "time": "2017-10-19T19:58:43+00:00"
         },
         {
-            "name": "orchestra/testbench",
-            "version": "v3.6.0",
+            "name": "ob-ivan/diversitest",
+            "version": "v0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/orchestral/testbench.git",
-                "reference": "30d0a9588477aacb8651d36b8a957a823faf8919"
+                "url": "https://github.com/ob-ivan/diversitest.git",
+                "reference": "baf09afe79ebe3f51ca569883752b668b457301e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/30d0a9588477aacb8651d36b8a957a823faf8919",
-                "reference": "30d0a9588477aacb8651d36b8a957a823faf8919",
+                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/baf09afe79ebe3f51ca569883752b668b457301e",
+                "reference": "baf09afe79ebe3f51ca569883752b668b457301e",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "~5.6.0",
-                "orchestra/testbench-core": "~3.6.0",
+                "symfony/console": "^3.0|^4.0",
+                "symfony/process": "^3.0|^4.0",
+                "symfony/yaml": "^3.0|^4.0",
+                "twig/twig": "^2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "bin": [
+                "diversitest"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ob_Ivan\\DiversiTest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "Run tests against varying dependencies versions",
+            "time": "2018-02-23T23:44:52+00:00"
+        },
+        {
+            "name": "orchestra/testbench",
+            "version": "v3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/testbench.git",
+                "reference": "24ea3330f448815ac3bea53611e944f6eee0c308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/24ea3330f448815ac3bea53611e944f6eee0c308",
+                "reference": "24ea3330f448815ac3bea53611e944f6eee0c308",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "~5.6.4",
+                "orchestra/testbench-core": "~3.6.3",
                 "php": ">=7.1",
                 "phpunit/phpunit": "~7.0"
             },
@@ -2450,20 +2326,20 @@
                 "orchestral",
                 "testing"
             ],
-            "time": "2018-02-07T22:51:17+00:00"
+            "time": "2018-02-20T05:32:04+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v3.6.0",
+            "version": "v3.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "7dcbff4c5d3e0038c04a4c37b874936ea6986c67"
+                "reference": "e07a2dd5b9399d56f487379ac3af515a4635bd6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/7dcbff4c5d3e0038c04a4c37b874936ea6986c67",
-                "reference": "7dcbff4c5d3e0038c04a4c37b874936ea6986c67",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/e07a2dd5b9399d56f487379ac3af515a4635bd6a",
+                "reference": "e07a2dd5b9399d56f487379ac3af515a4635bd6a",
                 "shasum": ""
             },
             "require": {
@@ -2514,7 +2390,7 @@
                 "orchestral",
                 "testing"
             ],
-            "time": "2018-02-07T22:49:44+00:00"
+            "time": "2018-02-20T04:08:58+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2772,16 +2648,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -2793,7 +2669,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -2831,7 +2707,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2018-02-19T10:16:54+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3084,16 +2960,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc"
+                "reference": "316555dbd0ed4097bbdd17c65ab416bf27a472e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc",
-                "reference": "9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/316555dbd0ed4097bbdd17c65ab416bf27a472e9",
+                "reference": "316555dbd0ed4097bbdd17c65ab416bf27a472e9",
                 "shasum": ""
             },
             "require": {
@@ -3160,20 +3036,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-02T05:04:08+00:00"
+            "time": "2018-02-13T06:08:08+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "e495e5d3660321b62c294d8c0e954d02d6ce2573"
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e495e5d3660321b62c294d8c0e954d02d6ce2573",
-                "reference": "e495e5d3660321b62c294d8c0e954d02d6ce2573",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
                 "shasum": ""
             },
             "require": {
@@ -3216,7 +3092,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-02-01T13:11:13+00:00"
+            "time": "2018-02-15T05:27:38+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3782,6 +3658,64 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
+                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-21T19:06:11+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.1.0",
             "source": {
@@ -3820,6 +3754,72 @@
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v2.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "eddb97148ad779f27e670e1e3f19fb323aedafeb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/eddb97148ad779f27e670e1e3f19fb323aedafeb",
+                "reference": "eddb97148ad779f27e670e1e3f19fb323aedafeb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/debug": "~2.7",
+                "symfony/phpunit-bridge": "~3.3@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Twig Team",
+                    "homepage": "http://twig.sensiolabs.org/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "http://twig.sensiolabs.org",
+            "keywords": [
+                "templating"
+            ],
+            "time": "2017-09-27T18:10:31+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b29de9f4c4aac1c14014864afd7d3868",
+    "content-hash": "4c0c6f6ce4af7d32793210e35c814a60",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -461,16 +461,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.6.5",
+            "version": "v5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "2e68209991e15aca1382ef9a3443d13f2e0d8755"
+                "reference": "db3e5422070d9b5166493313142b30419efab207"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/2e68209991e15aca1382ef9a3443d13f2e0d8755",
-                "reference": "2e68209991e15aca1382ef9a3443d13f2e0d8755",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/db3e5422070d9b5166493313142b30419efab207",
+                "reference": "db3e5422070d9b5166493313142b30419efab207",
                 "shasum": ""
             },
             "require": {
@@ -481,7 +481,7 @@
                 "ext-openssl": "*",
                 "league/flysystem": "~1.0",
                 "monolog/monolog": "~1.12",
-                "nesbot/carbon": "^1.22.1",
+                "nesbot/carbon": "~1.20",
                 "php": "^7.1.3",
                 "psr/container": "~1.0",
                 "psr/simple-cache": "^1.0",
@@ -527,7 +527,7 @@
                 "illuminate/translation": "self.version",
                 "illuminate/validation": "self.version",
                 "illuminate/view": "self.version",
-                "tightenco/collect": "<5.5.33"
+                "tightenco/collect": "self.version"
             },
             "require-dev": {
                 "aws/aws-sdk-php": "~3.0",
@@ -592,7 +592,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2018-02-22T19:21:38+00:00"
+            "time": "2018-02-09T13:33:22+00:00"
         },
         {
             "name": "league/flysystem",
@@ -2278,21 +2278,21 @@
         },
         {
             "name": "orchestra/testbench",
-            "version": "v3.6.2",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "24ea3330f448815ac3bea53611e944f6eee0c308"
+                "reference": "30d0a9588477aacb8651d36b8a957a823faf8919"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/24ea3330f448815ac3bea53611e944f6eee0c308",
-                "reference": "24ea3330f448815ac3bea53611e944f6eee0c308",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/30d0a9588477aacb8651d36b8a957a823faf8919",
+                "reference": "30d0a9588477aacb8651d36b8a957a823faf8919",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "~5.6.4",
-                "orchestra/testbench-core": "~3.6.3",
+                "laravel/framework": "~5.6.0",
+                "orchestra/testbench-core": "~3.6.0",
                 "php": ">=7.1",
                 "phpunit/phpunit": "~7.0"
             },
@@ -2326,20 +2326,20 @@
                 "orchestral",
                 "testing"
             ],
-            "time": "2018-02-20T05:32:04+00:00"
+            "time": "2018-02-07T22:51:17+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v3.6.3",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "e07a2dd5b9399d56f487379ac3af515a4635bd6a"
+                "reference": "7dcbff4c5d3e0038c04a4c37b874936ea6986c67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/e07a2dd5b9399d56f487379ac3af515a4635bd6a",
-                "reference": "e07a2dd5b9399d56f487379ac3af515a4635bd6a",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/7dcbff4c5d3e0038c04a4c37b874936ea6986c67",
+                "reference": "7dcbff4c5d3e0038c04a4c37b874936ea6986c67",
                 "shasum": ""
             },
             "require": {
@@ -2390,7 +2390,7 @@
                 "orchestral",
                 "testing"
             ],
-            "time": "2018-02-20T04:08:58+00:00"
+            "time": "2018-02-07T22:49:44+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2648,16 +2648,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -2669,7 +2669,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -2707,7 +2707,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2960,16 +2960,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "316555dbd0ed4097bbdd17c65ab416bf27a472e9"
+                "reference": "9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/316555dbd0ed4097bbdd17c65ab416bf27a472e9",
-                "reference": "316555dbd0ed4097bbdd17c65ab416bf27a472e9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc",
+                "reference": "9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc",
                 "shasum": ""
             },
             "require": {
@@ -3036,20 +3036,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-13T06:08:08+00:00"
+            "time": "2018-02-02T05:04:08+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "6.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
+                "reference": "e495e5d3660321b62c294d8c0e954d02d6ce2573"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
-                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e495e5d3660321b62c294d8c0e954d02d6ce2573",
+                "reference": "e495e5d3660321b62c294d8c0e954d02d6ce2573",
                 "shasum": ""
             },
             "require": {
@@ -3092,7 +3092,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-02-15T05:27:38+00:00"
+            "time": "2018-02-01T13:11:13+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6c3f4a84da7688edbe3ec85fdeda4f4",
+    "content-hash": "73f8ec398c6c55210f9e50a773e9b93b",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -2242,16 +2242,16 @@
         },
         {
             "name": "ob-ivan/diversitest",
-            "version": "v0.1",
+            "version": "v0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ob-ivan/diversitest.git",
-                "reference": "21c0649d013ca7b9fc2ec0f7ca69de1bad49570d"
+                "reference": "ce7ae585714c9cd0c349d93d90f3ae68cfa3157f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/21c0649d013ca7b9fc2ec0f7ca69de1bad49570d",
-                "reference": "21c0649d013ca7b9fc2ec0f7ca69de1bad49570d",
+                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/ce7ae585714c9cd0c349d93d90f3ae68cfa3157f",
+                "reference": "ce7ae585714c9cd0c349d93d90f3ae68cfa3157f",
                 "shasum": ""
             },
             "require": {
@@ -2272,7 +2272,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Run tests against varying dependencies versions",
-            "time": "2018-02-12T23:01:22+00:00"
+            "time": "2018-02-19T22:17:10+00:00"
         },
         {
             "name": "orchestra/testbench",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "48c01a79687883f52034568b7db1602c",
+    "content-hash": "d6c3f4a84da7688edbe3ec85fdeda4f4",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -2241,6 +2241,40 @@
             "time": "2017-10-19T19:58:43+00:00"
         },
         {
+            "name": "ob-ivan/diversitest",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ob-ivan/diversitest.git",
+                "reference": "21c0649d013ca7b9fc2ec0f7ca69de1bad49570d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/21c0649d013ca7b9fc2ec0f7ca69de1bad49570d",
+                "reference": "21c0649d013ca7b9fc2ec0f7ca69de1bad49570d",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/console": "^4.0",
+                "symfony/yaml": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "bin": [
+                "diversitest"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ob_Ivan\\DiversiTest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "Run tests against varying dependencies versions",
+            "time": "2018-02-12T23:01:22+00:00"
+        },
+        {
             "name": "orchestra/testbench",
             "version": "v3.6.0",
             "source": {
@@ -3620,6 +3654,64 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
+                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-21T19:06:11+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f299ba419a30d76e66c8a3f4ec646756",
+    "content-hash": "b29de9f4c4aac1c14014864afd7d3868",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -2242,23 +2242,23 @@
         },
         {
             "name": "ob-ivan/diversitest",
-            "version": "v0.5",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ob-ivan/diversitest.git",
-                "reference": "baf09afe79ebe3f51ca569883752b668b457301e"
+                "reference": "209e795f9b24587086bbfa1a836a2828a09e3f2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/baf09afe79ebe3f51ca569883752b668b457301e",
-                "reference": "baf09afe79ebe3f51ca569883752b668b457301e",
+                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/209e795f9b24587086bbfa1a836a2828a09e3f2e",
+                "reference": "209e795f9b24587086bbfa1a836a2828a09e3f2e",
                 "shasum": ""
             },
             "require": {
                 "symfony/console": "^3.0|^4.0",
                 "symfony/process": "^3.0|^4.0",
                 "symfony/yaml": "^3.0|^4.0",
-                "twig/twig": "^2.4"
+                "twig/twig": "^1.0|^2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.0"
@@ -2274,7 +2274,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Run tests against varying dependencies versions",
-            "time": "2018-02-23T23:44:52+00:00"
+            "time": "2018-02-24T20:17:33+00:00"
         },
         {
             "name": "orchestra/testbench",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "38f9111aa212aede13b1b3377d5789be",
+    "content-hash": "a95fb8fcb90f283c1044bf026e3271c1",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -811,22 +811,23 @@
         },
         {
             "name": "ob-ivan/diversitest",
-            "version": "v0.4.1",
+            "version": "v0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ob-ivan/diversitest.git",
-                "reference": "b39417da9bd6b802b86d64765b54acb8d42b842d"
+                "reference": "baf09afe79ebe3f51ca569883752b668b457301e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/b39417da9bd6b802b86d64765b54acb8d42b842d",
-                "reference": "b39417da9bd6b802b86d64765b54acb8d42b842d",
+                "url": "https://api.github.com/repos/ob-ivan/diversitest/zipball/baf09afe79ebe3f51ca569883752b668b457301e",
+                "reference": "baf09afe79ebe3f51ca569883752b668b457301e",
                 "shasum": ""
             },
             "require": {
                 "symfony/console": "^3.0|^4.0",
                 "symfony/process": "^3.0|^4.0",
-                "symfony/yaml": "^3.0|^4.0"
+                "symfony/yaml": "^3.0|^4.0",
+                "twig/twig": "^2.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.0"
@@ -842,7 +843,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Run tests against varying dependencies versions",
-            "time": "2018-02-23T21:27:44+00:00"
+            "time": "2018-02-23T23:44:52+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -2131,6 +2132,72 @@
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "time": "2017-11-27T11:13:29+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v2.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "eddb97148ad779f27e670e1e3f19fb323aedafeb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/eddb97148ad779f27e670e1e3f19fb323aedafeb",
+                "reference": "eddb97148ad779f27e670e1e3f19fb323aedafeb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/debug": "~2.7",
+                "symfony/phpunit-bridge": "~3.3@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Twig Team",
+                    "homepage": "http://twig.sensiolabs.org/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "http://twig.sensiolabs.org",
+            "keywords": [
+                "templating"
+            ],
+            "time": "2017-09-27T18:10:31+00:00"
         },
         {
             "name": "vlucas/phpdotenv",

--- a/diversitest.yaml
+++ b/diversitest.yaml
@@ -2,5 +2,6 @@ package_manager: 'composer'
 test_runner: 'vendor/bin/phpunit'
 packages:
     illuminate/support:
-        - ~5.4
-        - ^5.5
+        - 5.4.*
+        - 5.5.*
+        - 5.6.*

--- a/diversitest.yaml
+++ b/diversitest.yaml
@@ -1,0 +1,6 @@
+package_manager: 'composer require $package $version'
+test_runner: 'vendor/bin/phpunit'
+packages:
+	illuminate/support:
+		- 5.4.*
+		- ^5.5

--- a/diversitest.yaml
+++ b/diversitest.yaml
@@ -1,6 +1,6 @@
 package_manager: 'composer require $package $version'
 test_runner: 'vendor/bin/phpunit'
 packages:
-	illuminate/support:
-		- 5.4.*
-		- ^5.5
+    illuminate/support:
+        - 5.4.*
+        - ^5.5

--- a/diversitest.yaml
+++ b/diversitest.yaml
@@ -1,6 +1,6 @@
-package_manager: 'composer require $package $version'
+package_manager: 'composer'
 test_runner: 'vendor/bin/phpunit'
 packages:
     illuminate/support:
-        - 5.4.*
+        - ~5.4
         - ^5.5


### PR DESCRIPTION
Adding a development version of DiversiTest: a new utility to run tests with a range of dependencies' versions.

Run `composer install`, then:

```
vendor/bin/diversitest
```

This will clone current working directory to a temporary folder, install dependencies' versions as configured in `diversitest.yaml` and run `phpunit`.

You can check the source here: https://github.com/ob-ivan/diversitest

TODO:
- [x] Downgrade `symfony/console` to 3.*
- [x] Downgrade `symfony/process` to 3.*